### PR TITLE
Revert "Build: Make dex2oat boot image error abort explicit"

### DIFF
--- a/core/dex_preopt_libart_boot.mk
+++ b/core/dex_preopt_libart_boot.mk
@@ -118,8 +118,6 @@ $($(my_2nd_arch_prefix)DEFAULT_DEX_PREOPT_BUILT_IMAGE_FILENAME) : $(LIBART_TARGE
 		--runtime-arg -Xnorelocate --compile-pic \
 		--no-generate-debug-info --generate-build-id \
 		--multi-image --no-inline-from=core-oj.jar \
-		--abort-on-hard-verifier-error \
-		--abort-on-soft-verifier-error \
 		$(PRODUCT_DEX_PREOPT_BOOT_FLAGS) $(GLOBAL_DEXPREOPT_FLAGS) $(ART_BOOT_IMAGE_EXTRA_ARGS) \
 		|| ( echo "$(DEX2OAT_FAILURE_MESSAGE)" ; false ) && \
 	$(DEX2OAT_BOOT_IMAGE_LOG_TAGS) ANDROID_ROOT=$(PRODUCT_OUT)/system ANDROID_DATA=$(dir $@) $(PATCHOAT) \


### PR DESCRIPTION
This reverts commit 87dded449494cc7ff9c7e0aee967031cd10c62e9

Restore oreo behavior

Change-Id: I5d6ec974050f6d5d0955d6b4eb284f0606905e03
Signed-off-by: DennySPB <dennyspb@gmail.com>