### PR TITLE
envsetup: add syncc alias

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -54,6 +54,11 @@ EOF
     echo $A
 }
 
+# Repo sync with various flags I'm lazy to type each time
+function syncc() {
+    time repo sync --force-sync --no-clone-bundle --current-branch --no-tags "$@"
+}
+
 # Get all the build variables needed by this script in a single call to the build system.
 function build_build_var_cache()
 {


### PR DESCRIPTION
instead of having to goto AOSiP/platform_manifest each time to grab the sync command lets just add the alias here.

Co-authored-by: Akhil Narang <me@akhilnarang.dev>