### PR TITLE
Bump Security String to 2021-10-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-09-05
+      PLATFORM_SECURITY_PATCH := 2021-10-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0651   A-67013844   DoS    High       9, 10, 11
CVE-2021-0652   A-185178568  EoP    High       8.1, 9, 10, 11
CVE-2021-0706   A-193444889  DoS    High       8.1, 9, 10, 11
CVE-2021-0870   A-192472262  RCE    Critical   8.1, 9, 10, 11

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:  Prior Change:
CVE-2021-0708   A-183262161  EoP    High       8.1, 9, 10, 11          a6ddce2b3c60

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-15358  A-192605364  ID     High       11
CVE-2021-0483   A-153358911  EoP    High       10, 11
CVE-2021-0643   A-183612370  ID     High       10, 11
CVE-2021-0702   A-193932765  ID     High       11
CVE-2021-0703   A-184569329  EoP    High       11
CVE-2021-0705   A-185388103  EoP    High       10, 11

Change-Id: I2da3d140792c2d001774d6501fd0f64792539f8f