### PR TITLE
Bump Security String to 2021-11-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -231,7 +231,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-10-05
+      PLATFORM_SECURITY_PATCH := 2021-11-05
 endif
 
 ifndef PLATFORM_SECURITY_PATCH_TIMESTAMP


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0919   A-197336441  DoS    Moderate   9, 10, 11
CVE-2021-0926   A-191053931  EoP    High       9, 10, 11, 12
CVE-2021-0927   A-189824175  EoP    High
CVE-2021-0928   A-188675581  EoP    High       9, 10, 11
CVE-2021-0930   A-181660091  RCE    Critical   9, 10, 11, 12
CVE-2021-0931   A-180747689  ID     High       9, 10, 11, 12
CVE-2021-0933   A-172251622  EoP    High       9, 10, 11, 12

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:  Prior Change:
CVE-2021-0434   A-167403112  EoP    High       9, 10, 11               2aeb529569, 180f7eea2e
CVE-2021-0650   A-190286685  ID     High       9, 10, 11               847b331
CVE-2021-0653   A-177931370  ID     High       9, 10, 11               aaf9698e514a

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-13871  A-192606047  ID     High       11
CVE-2021-0649   A-191382886  EoP    High       11
CVE-2021-0799   A-197647956  EoP    High       12
CVE-2021-0921   A-195962697  EoP    High       11
CVE-2021-0922   A-195630721  EoP    Moderate   11
CVE-2021-0918   A-197536150  RCE    Critical   12
CVE-2021-0923   A-195338390  EoP    High       12
CVE-2021-0925   A-191444150  ID     High       12
CVE-2021-0932   A-173025705  EoP    High       10 (OBE due to 4f1e9151610b)

Change-Id: Ic207b4ea19b6f638969ff66f20fa316c2e3f7e5e